### PR TITLE
Fix extra blank lines in CSV dataframe output on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for pycpg consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## 1.0.4
+
+### Fixed
+
+- Fixed extra blank lines between rows in CSV output of file-event/dataframe results on Windows.
+
 ## 1.0.3
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Fixed
 
 - Fixed extra blank lines between rows in CSV output of file-event/dataframe results on Windows.
+- Stabilized `FileOrString` encoding auto-detection test that could fail depending on the installed `chardet` version.
 
 ## 1.0.3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 license = "MIT"
 license-files = ["LICENSE.md"]
 name = "crashplancli"
-version = "1.0.3"
+version = "1.0.4"
 description = "The official command line tool for interacting with CrashPlan"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.11, <4"

--- a/src/crashplancli/output_formats.py
+++ b/src/crashplancli/output_formats.py
@@ -116,9 +116,15 @@ class DataFrameOutputFormatter:
             kwargs = {"index": False, "header": header, **kwargs}
             if columns:
                 filtered = self._select_columns(df, columns)
-                formatted_rows = filtered.to_csv(**kwargs).splitlines(keepends=True)
+                csv_text = filtered.to_csv(**kwargs)
             else:
-                formatted_rows = df.to_csv(**kwargs).splitlines(keepends=True)
+                csv_text = df.to_csv(**kwargs)
+            # pandas defaults its line terminator to os.linesep, which is "\r\n"
+            # on Windows. When these rows are echoed to a text-mode stdout the
+            # "\n" gets translated to "\r\n" again, producing "\r\r\n" and a
+            # blank line between rows. Normalize to "\n" (as to_csv() does via
+            # StringIO(newline=None)) so Windows applies its "\r" exactly once.
+            formatted_rows = csv_text.replace("\r\n", "\n").splitlines(keepends=True)
             if header:
                 yield formatted_rows.pop(0)
 

--- a/tests/test_file_readers.py
+++ b/tests/test_file_readers.py
@@ -95,7 +95,14 @@ def test_AutoDecodedFile_raises_expected_exception_when_file_not_exists(runner):
     ["utf8", "utf16", "latin_1"],
 )
 def test_FileOrString_arg_handles_various_encodings_automatically(runner, encoding):
-    test_data = '{"tést": "dåta"}'
+    # FileOrString auto-detects encoding with chardet, which needs a
+    # representative amount of text to distinguish single-byte encodings (a tiny
+    # sample of accented chars is ambiguous between e.g. latin-1 and latin-2).
+    test_data = (
+        '{"note": "The naïve café in Zürich serves a fine résumé of Málaga '
+        "tapas. Señor Muñoz built the façade; guests coöperate at the fête in "
+        'Besançon."}'
+    )
     with runner.isolated_filesystem():
         with open("test1.json", "w", encoding=encoding) as file:
             file.write(test_data)

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -1,0 +1,45 @@
+from pandas import DataFrame
+
+from crashplancli.enums import OutputFormat
+from crashplancli.output_formats import DataFrameOutputFormatter
+from crashplancli.output_formats import to_csv
+
+TEST_DATA = [
+    {"a": "1", "b": "2"},
+    {"a": "3", "b": "4"},
+]
+
+TEST_DATAFRAME = DataFrame(
+    [
+        {"string_column": "string1", "int_column": 42, "null_column": None},
+        {"string_column": "string2", "int_column": 43, "null_column": None},
+    ]
+)
+
+
+def test_to_csv_uses_unix_line_endings_to_avoid_extra_windows_line_breaks():
+    # csv.DictWriter emits "\r\n" line endings. to_csv() writes into a
+    # StringIO(newline=None), which strips those to "\n". This matters because
+    # the result is echoed to stdout: on Windows a text-mode stdout translates
+    # "\n" -> "\r\n", so if the "\r" were left in we'd get "\r\r\n" and a blank
+    # line between every row.
+    formatted_output = to_csv(TEST_DATA)
+    assert "\r" not in formatted_output
+    assert "\n" in formatted_output
+
+
+def test_dataframe_csv_formatter_normalizes_windows_line_endings():
+    # pandas defaults its line terminator to os.linesep, so on Windows to_csv()
+    # emits "\r\n". Those rows would become "\r\r\n" (a blank line between every
+    # row) once echoed to a text-mode stdout. Forcing the "\r\n" terminator here
+    # reproduces the Windows output on any OS; the formatter must strip the "\r"
+    # and yield "\n"-only rows.
+    formatter = DataFrameOutputFormatter(OutputFormat.CSV)
+    output = "".join(
+        formatter.get_formatted_output(TEST_DATAFRAME, lineterminator="\r\n")
+    )
+    assert "\r" not in output
+    assert (
+        output
+        == "string_column,int_column,null_column\nstring1,42,\nstring2,43,\n"
+    )

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -39,7 +39,4 @@ def test_dataframe_csv_formatter_normalizes_windows_line_endings():
         formatter.get_formatted_output(TEST_DATAFRAME, lineterminator="\r\n")
     )
     assert "\r" not in output
-    assert (
-        output
-        == "string_column,int_column,null_column\nstring1,42,\nstring2,43,\n"
-    )
+    assert output == "string_column,int_column,null_column\nstring1,42,\nstring2,43,\n"


### PR DESCRIPTION
## Summary

CSV output of file-event / dataframe results has extra blank lines between rows on Windows.

`pandas.DataFrame.to_csv()` defaults its line terminator to `os.linesep`, which is `\r\n` on Windows. `DataFrameOutputFormatter._iter_csv` preserved those endings via `splitlines(keepends=True)`, so when the rows were echoed to a text-mode stdout the `\n` was translated to `\r\n` again — producing `\r\r\n` and a blank line between every row.

The fix normalizes the pandas output to `\n` before splitting, mirroring what the stdlib `to_csv()` already achieves via `StringIO(newline=None)`, so Windows applies its `\r` exactly once. It's a no-op on Linux/macOS.

Note the stdlib `to_csv()` path was already protected by `StringIO(newline=None)` and is unchanged; only the pandas path needed the fix.

## Changes

- `src/crashplancli/output_formats.py` — normalize line endings in `_iter_csv`
- `tests/test_output_formats.py` — new regression tests for both CSV paths (this module had no test file)
- Bumped version `1.0.3` → `1.0.4` + CHANGELOG entry

### Also included: unrelated CI fix

CI was red on a pre-existing failure unrelated to this change: `test_FileOrString_arg_handles_various_encodings_automatically[latin_1]`. `FileOrString` auto-detects encoding with `chardet`, which can't reliably distinguish single-byte encodings from a tiny sample — a newer `chardet` detected the 16-byte latin_1 sample as iso8859-2, decoding `å` as `ĺ`. Replaced the sample with longer, representative Western-European text so detection is reliable. (`tests/test_file_readers.py`)

## Testing

Full suite (367 tests) passes locally against pandas 3.0.3 and chardet 7.4.3. Temporarily reverting the CSV fix makes the dataframe test fail (output contains `\r\n`), confirming it genuinely guards the behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)